### PR TITLE
Fix a small bug related to .pyc files.

### DIFF
--- a/IPython/extensions/slidemode.py
+++ b/IPython/extensions/slidemode.py
@@ -27,7 +27,7 @@ import os
 path = os.path.realpath(__file__)
 print(path)
 
-f = io.open(path[:-2]+'js')
+f = io.open('.'.join(path.split('.')[:-1] + ['js']))
 
 js= f.read()
 


### PR DESCRIPTION
If **file** returns a file ending in .pyc (as it sometimes does, apparently) the original code would break and look for slidemode.pjs. This uses a safer filename mangling.
