### PR TITLE
revert inputhook param location

### DIFF
--- a/IPython/terminal/debugger.py
+++ b/IPython/terminal/debugger.py
@@ -66,7 +66,7 @@ class TerminalPdb(Pdb):
         )
 
         if not PTK3:
-            options['inputhook'] = self.inputhook
+            options['inputhook'] = self.shell.inputhook
         self.pt_app = PromptSession(**options)
 
     def cmdloop(self, intro=None):


### PR DESCRIPTION
In https://github.com/ipython/ipython/pull/11979, a fix was made for `ipdb` however, the location of the param lookup was changed by accident? it is certainly breaking it for me.